### PR TITLE
Use Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
-          java-version: '21'
+          java-version: '17'
           distribution: 'temurin'
           cache: gradle
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -116,8 +116,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_21
-        targetCompatibility JavaVersion.VERSION_21
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     buildFeatures {


### PR DESCRIPTION
When I tried to do a `./gradlew assembleRelease` from `master`, I got 

> Inconsistent JVM-target compatibility detected for tasks 'compileReleaseJavaWithJavac' (21) and 'compileReleaseKotlin' (17)

 I looked at Collect and Collect uses Java 17 for everything so I've matched that and verify I can release.

#### What has been done to verify that this works as intended?
`./gradlew assembleRelease` and then tried on device.

#### Why is this the best possible solution? Were any other approaches considered?
I considered setting the Kotlin jvm target instead but I'd rather match the versions we use for Collect.

#### Are there any risks to merging this code? If so, what are they?
Can't currently think of one!